### PR TITLE
Change .ens to .eth in error message

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -56,7 +56,7 @@ Explanation of this source code architecture and how it is organized. For more o
 - **in3.eth.api**: Ethereum API.
 - **in3.eth.account**: Ethereum accounts.
 - **in3.eth.contract**: Ethereum smart-contracts API.
-- **in3.eth.model**: MVC Model classes for the Ethereum client module domain. Manages serializaation.
+- **in3.eth.model**: MVC Model classes for the Ethereum client module domain. Manages serialization.
 - **in3.eth.factory**: Ethereum Object Factory. Manages deserialization.
 - **in3.libin3**: Module for the libin3 runtime. Libin3 is written in C and can be found [here](https://github.com/slockit/in3-c).
 - **in3.libin3.shared**: Native shared libraries for multiple operating systems and platforms.

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -86,7 +86,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .ens')
+            raise AssertionError('Client: ENS domain name must end with .eth')
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'addr', registry)
 
     def ens_owner(self, domain_name: str, registry: str = None) -> str:

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -4,6 +4,8 @@ from in3.eth.api import EthereumApi
 from in3.eth.factory import EthObjectFactory
 from in3.libin3.enum import In3Methods
 from in3.libin3.runtime import In3Runtime
+from in3.exception import EnsDomainFormatAssertionError
+
 from in3.model import In3Node, NodeList, ClientConfig, chain_configs
 from in3.transport import https_transport
 
@@ -69,7 +71,7 @@ class Client:
             node (str): Formatted string referred as `node` in ENS documentation
         """
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .eth')
+            raise EnsDomainFormatAssertionError()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'hash')
 
     def ens_address(self, domain_name: str, registry: str = None) -> str:
@@ -86,7 +88,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .eth')
+            raise EnsDomainFormatAssertionError()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'addr', registry)
 
     def ens_owner(self, domain_name: str, registry: str = None) -> str:
@@ -101,7 +103,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .eth')
+            raise EnsDomainFormatAssertionError()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'owner', registry)
 
     def ens_resolver(self, domain_name: str, registry: str = None) -> str:
@@ -116,7 +118,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .eth')
+            raise EnsDomainFormatAssertionError()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'resolver', registry)
 
 

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -4,7 +4,7 @@ from in3.eth.api import EthereumApi
 from in3.eth.factory import EthObjectFactory
 from in3.libin3.enum import In3Methods
 from in3.libin3.runtime import In3Runtime
-from in3.exception import EnsDomainFormatAssertionException
+from in3.exception import EnsDomainFormatException
 from in3.model import In3Node, NodeList, ClientConfig, chain_configs
 from in3.transport import https_transport
 
@@ -70,7 +70,7 @@ class Client:
             node (str): Formatted string referred as `node` in ENS documentation
         """
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionException()
+            raise EnsDomainFormatException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'hash')
 
     def ens_address(self, domain_name: str, registry: str = None) -> str:
@@ -87,7 +87,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionException()
+            raise EnsDomainFormatException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'addr', registry)
 
     def ens_owner(self, domain_name: str, registry: str = None) -> str:
@@ -102,7 +102,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionException()
+            raise EnsDomainFormatException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'owner', registry)
 
     def ens_resolver(self, domain_name: str, registry: str = None) -> str:
@@ -117,7 +117,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionException()
+            raise EnsDomainFormatException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'resolver', registry)
 
 

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -69,7 +69,7 @@ class Client:
             node (str): Formatted string referred as `node` in ENS documentation
         """
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .ens')
+            raise AssertionError('Client: ENS domain name must end with .eth')
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'hash')
 
     def ens_address(self, domain_name: str, registry: str = None) -> str:
@@ -101,7 +101,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .ens')
+            raise AssertionError('Client: ENS domain name must end with .eth')
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'owner', registry)
 
     def ens_resolver(self, domain_name: str, registry: str = None) -> str:
@@ -116,7 +116,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise AssertionError('Client: ENS domain name must end with .ens')
+            raise AssertionError('Client: ENS domain name must end with .eth')
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'resolver', registry)
 
 

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -4,7 +4,7 @@ from in3.eth.api import EthereumApi
 from in3.eth.factory import EthObjectFactory
 from in3.libin3.enum import In3Methods
 from in3.libin3.runtime import In3Runtime
-from in3.exception import EnsDomainFormatAssertionError
+from in3.exception import EnsDomainFormatAssertionException
 
 from in3.model import In3Node, NodeList, ClientConfig, chain_configs
 from in3.transport import https_transport
@@ -71,7 +71,7 @@ class Client:
             node (str): Formatted string referred as `node` in ENS documentation
         """
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionError()
+            raise EnsDomainFormatAssertionException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'hash')
 
     def ens_address(self, domain_name: str, registry: str = None) -> str:
@@ -88,7 +88,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionError()
+            raise EnsDomainFormatAssertionException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'addr', registry)
 
     def ens_owner(self, domain_name: str, registry: str = None) -> str:
@@ -103,7 +103,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionError()
+            raise EnsDomainFormatAssertionException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'owner', registry)
 
     def ens_resolver(self, domain_name: str, registry: str = None) -> str:
@@ -118,7 +118,7 @@ class Client:
         if registry:
             registry = self._factory.get_address(registry)
         if not isinstance(domain_name, str) or not re.match(r'(\w+.eth$)', domain_name):
-            raise EnsDomainFormatAssertionError()
+            raise EnsDomainFormatAssertionException()
         return self._runtime.call(In3Methods.ENSRESOLVE, domain_name, 'resolver', registry)
 
 

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -5,7 +5,6 @@ from in3.eth.factory import EthObjectFactory
 from in3.libin3.enum import In3Methods
 from in3.libin3.runtime import In3Runtime
 from in3.exception import EnsDomainFormatAssertionException
-
 from in3.model import In3Node, NodeList, ClientConfig, chain_configs
 from in3.transport import https_transport
 

--- a/python/in3/exception.py
+++ b/python/in3/exception.py
@@ -33,6 +33,6 @@ class TransportException(IN3BaseException):
     pass
 
 
-class EnsDomainFormatAssertionError(AssertionError):
+class EnsDomainFormatAssertionException(AssertionError):
     def __init__(self):
         super().__init__('Client: ENS domain name must end with .eth')

--- a/python/in3/exception.py
+++ b/python/in3/exception.py
@@ -33,6 +33,6 @@ class TransportException(IN3BaseException):
     pass
 
 
-class EnsDomainFormatAssertionException(AssertionError):
+class EnsDomainFormatAssertionException(IN3BaseException):
     def __init__(self):
         super().__init__('Client: ENS domain name must end with .eth')

--- a/python/in3/exception.py
+++ b/python/in3/exception.py
@@ -31,3 +31,8 @@ class ClientException(IN3BaseException):
 class TransportException(IN3BaseException):
     """ In3 Request exception  """
     pass
+
+
+class EnsDomainFormatAssertionError(AssertionError):
+    def __init__(self):
+        super().__init__('Client: ENS domain name must end with .eth')

--- a/python/in3/exception.py
+++ b/python/in3/exception.py
@@ -33,6 +33,6 @@ class TransportException(IN3BaseException):
     pass
 
 
-class EnsDomainFormatAssertionException(IN3BaseException):
+class EnsDomainFormatException(IN3BaseException):
     def __init__(self):
         super().__init__('Client: ENS domain name must end with .eth')

--- a/python/in3/exception.py
+++ b/python/in3/exception.py
@@ -24,10 +24,10 @@ class HashFormatException(IN3BaseException):
 
 
 class ClientException(IN3BaseException):
-    """ In3 Request expecetion  """
+    """ In3 Request exception  """
     pass
 
 
 class TransportException(IN3BaseException):
-    """ In3 Request expecetion  """
+    """ In3 Request exception  """
     pass

--- a/python/tests/integrated/negative/client_test.py
+++ b/python/tests/integrated/negative/client_test.py
@@ -42,7 +42,7 @@ class ClientNegativeTest(unittest.TestCase):
     def test_ens_namehash(self):
         for i in range(50):
             with self.assertRaises(in3.ClientException):
-                self.client.ens_namehash('0x0.eth')
+                self.client.ens_namehash('0x0.ens')
 
 
 class ClientParsingTest(unittest.TestCase):

--- a/python/tests/integrated/negative/client_test.py
+++ b/python/tests/integrated/negative/client_test.py
@@ -42,7 +42,7 @@ class ClientNegativeTest(unittest.TestCase):
     def test_ens_namehash(self):
         for i in range(50):
             with self.assertRaises(in3.ClientException):
-                self.client.ens_namehash('0x0.ens')
+                self.client.ens_namehash('0x0.eth')
 
 
 class ClientParsingTest(unittest.TestCase):

--- a/python/tests/integrated/negative/client_test.py
+++ b/python/tests/integrated/negative/client_test.py
@@ -95,13 +95,13 @@ class ClientParsingTest(unittest.TestCase):
             self.client.ens_owner('depraz.eth', True)
         with self.assertRaises(in3.EthAddressFormatException):
             self.client.ens_owner('depraz.eth', '123')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_owner('depraz')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_owner('depraz.')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_owner('depraz.etho')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_owner('.eth')
 
     def test_ens_resolver(self):
@@ -115,13 +115,13 @@ class ClientParsingTest(unittest.TestCase):
             self.client.ens_resolver('depraz.eth', True)
         with self.assertRaises(in3.EthAddressFormatException):
             self.client.ens_resolver('depraz.eth', '123')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_resolver('depraz')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_resolver('depraz.')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_resolver('depraz.etho')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_resolver('.eth')
 
     def test_ens_address(self):
@@ -135,23 +135,23 @@ class ClientParsingTest(unittest.TestCase):
             self.client.ens_address('depraz.eth', True)
         with self.assertRaises(in3.EthAddressFormatException):
             self.client.ens_address('depraz.eth', '123')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_address('depraz')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_address('depraz.')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_address('depraz.etho')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_address('.eth')
 
     def test_ens_namehash(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_namehash('depraz')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_namehash('depraz.')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_namehash('depraz.etho')
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(in3.exception.EnsDomainFormatException):
             self.client.ens_namehash('.eth')
 
 


### PR DESCRIPTION
### Summary

The error message was suggestion the domain name had to end with .ens when it is supposed to be .eth.

### Other Information

N/a