### PR TITLE
Chain const

### DIFF
--- a/python/docs/documentation.md
+++ b/python/docs/documentation.md
@@ -77,6 +77,7 @@ source : [in3-c/python/examples/connect_to_ethereum.py](https://github.com/slock
 Connects to Ethereum and fetches attested information from each chain.
 """
 import in3
+from in3.model import Chain
 
 
 print('\nEthereum Main Network')
@@ -86,13 +87,13 @@ gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))
 
 print('\nEthereum Kovan Test Network')
-client = in3.Client('kovan')
+client = in3.Client(Chain.KOVAN)
 latest_block = client.eth.block_number()
 gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))
 
 print('\nEthereum Goerli Test Network')
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 latest_block = client.eth.block_number()
 gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))
@@ -125,9 +126,10 @@ source : [in3-c/python/examples/incubed_network.py](https://github.com/slockit/i
 Shows Incubed Network Nodes Stats
 """
 import in3
+from in3.model import Chain
 
 print('\nEthereum Goerli Test Network')
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 node_list = client.refresh_node_list()
 print('\nIncubed Registry:')
 print('\ttotal servers:', node_list.totalServers)
@@ -210,6 +212,7 @@ Resolves ENS domains to Ethereum addresses
 ENS is a smart-contract system that registers and resolves `.eth` domains.
 """
 import in3
+from in3.model import Chain
 
 
 def _print():
@@ -223,21 +226,21 @@ domain = 'depraz.eth'
 print('\nEthereum Name Service')
 
 # Instantiate In3 Client for Goerli
-chain = 'goerli'
+chain = Chain.GOERLI
 client = in3.Client(chain, cache_enabled=False)
 address = client.ens_address(domain)
 # owner = client.ens_owner(domain)
 # _print()
 
 # Instantiate In3 Client for Mainnet
-chain = 'mainnet'
+chain = Chain.MAINNET
 client = in3.Client(chain, cache_enabled=False)
 address = client.ens_address(domain)
 owner = client.ens_owner(domain)
 _print()
 
 # Instantiate In3 Client for Kovan
-chain = 'kovan'
+chain = Chain.KOVAN
 client = in3.Client(chain, cache_enabled=True)
 try:
     address = client.ens_address(domain)
@@ -273,6 +276,7 @@ Works with included `data` field for smart-contract calls.
 """
 import json
 import in3
+from in3.model import Chain
 import time
 
 
@@ -285,8 +289,8 @@ receiver = input("Receiver address: ")
 #              1000000000 == 1 Gwei Check https://etherscan.io/gasTracker.
 value_in_wei = 1463926659
 # None for Eth mainnet
-chain = 'goerli'
-client = in3.Client(chain if chain else 'mainnet')
+chain = Chain.GOERLI
+client = in3.Client(chain if chain else Chain.MAINNET)
 # A transaction is only final if a certain number of blocks are mined on top of it.
 # This number varies with the chain's consensus algorithm. Time can be calculated over using:
 # wait_time = blocks_for_consensus * avg_block_time_in_secs
@@ -363,9 +367,10 @@ Manually calling ENS smart-contract
 ![UML Sequence Diagram of how Ethereum Name Service ENS resolves a name.](https://lh5.googleusercontent.com/_OPPzaxTxKggx9HuxloeWtK8ggEfIIBKRCEA6BKMwZdzAfUpIY6cz7NK5CFmiuw7TwknbhFNVRCJsswHLqkxUEJ5KdRzpeNbyg8_H9d2RZdG28kgipT64JyPZUP--bAizozaDcxCq34)
 """
 import in3
+from in3.model import Chain
 
 
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 domain_name = client.ens_namehash('depraz.eth')
 ens_registry_addr = '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e'
 ens_resolver_abi = 'resolver(bytes32):address'
@@ -418,13 +423,14 @@ import base64
 import json
 
 import in3
+from in3.model import Chain
 import hashlib
 import random
 import time
 
 if __name__ == '__main__':
 
-    c = in3.Client(chain='ewc', in3_config=in3.ClientConfig(transport_binary_format=True))
+    c = in3.Client(chain=Chain.EWC, in3_config=in3.ClientConfig(transport_binary_format=True))
 
     smart_meter_registry_addr = '0xf23FF7472FC62C6bEe2F960f5b4170Ab3C1C26d2'
     # meter, bucket, operator, timestamp, data

--- a/python/docs/documentation.md
+++ b/python/docs/documentation.md
@@ -77,7 +77,7 @@ source : [in3-c/python/examples/connect_to_ethereum.py](https://github.com/slock
 Connects to Ethereum and fetches attested information from each chain.
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 print('\nEthereum Main Network')
@@ -126,7 +126,7 @@ source : [in3-c/python/examples/incubed_network.py](https://github.com/slockit/i
 Shows Incubed Network Nodes Stats
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 print('\nEthereum Goerli Test Network')
 client = in3.Client(Chain.GOERLI)
@@ -212,7 +212,7 @@ Resolves ENS domains to Ethereum addresses
 ENS is a smart-contract system that registers and resolves `.eth` domains.
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 def _print():
@@ -276,7 +276,7 @@ Works with included `data` field for smart-contract calls.
 """
 import json
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 import time
 
 
@@ -367,7 +367,7 @@ Manually calling ENS smart-contract
 ![UML Sequence Diagram of how Ethereum Name Service ENS resolves a name.](https://lh5.googleusercontent.com/_OPPzaxTxKggx9HuxloeWtK8ggEfIIBKRCEA6BKMwZdzAfUpIY6cz7NK5CFmiuw7TwknbhFNVRCJsswHLqkxUEJ5KdRzpeNbyg8_H9d2RZdG28kgipT64JyPZUP--bAizozaDcxCq34)
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 client = in3.Client(Chain.GOERLI)
@@ -423,7 +423,7 @@ import base64
 import json
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 import hashlib
 import random
 import time

--- a/python/examples/connect_to_ethereum.py
+++ b/python/examples/connect_to_ethereum.py
@@ -2,7 +2,7 @@
 Connects to Ethereum and fetches attested information from each chain.
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 print('\nEthereum Main Network')

--- a/python/examples/connect_to_ethereum.py
+++ b/python/examples/connect_to_ethereum.py
@@ -2,6 +2,7 @@
 Connects to Ethereum and fetches attested information from each chain.
 """
 import in3
+from in3.model import Chain
 
 
 print('\nEthereum Main Network')
@@ -11,13 +12,13 @@ gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))
 
 print('\nEthereum Kovan Test Network')
-client = in3.Client('kovan')
+client = in3.Client(Chain.KOVAN)
 latest_block = client.eth.block_number()
 gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))
 
 print('\nEthereum Goerli Test Network')
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 latest_block = client.eth.block_number()
 gas_price = client.eth.gas_price()
 print('Latest BN: {}\nGas Price: {} Wei'.format(latest_block, gas_price))

--- a/python/examples/incubed_network.py
+++ b/python/examples/incubed_network.py
@@ -2,7 +2,7 @@
 Shows Incubed Network Nodes Stats
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 print('\nEthereum Goerli Test Network')
 client = in3.Client(Chain.GOERLI)

--- a/python/examples/incubed_network.py
+++ b/python/examples/incubed_network.py
@@ -2,9 +2,10 @@
 Shows Incubed Network Nodes Stats
 """
 import in3
+from in3.model import Chain
 
 print('\nEthereum Goerli Test Network')
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 node_list = client.refresh_node_list()
 print('\nIncubed Registry:')
 print('\ttotal servers:', node_list.totalServers)

--- a/python/examples/resolve_eth_names.py
+++ b/python/examples/resolve_eth_names.py
@@ -3,6 +3,7 @@ Resolves ENS domains to Ethereum addresses
 ENS is a smart-contract system that registers and resolves `.eth` domains.
 """
 import in3
+from in3.model import Chain
 
 
 def _print():
@@ -16,21 +17,21 @@ domain = 'depraz.eth'
 print('\nEthereum Name Service')
 
 # Instantiate In3 Client for Goerli
-chain = 'goerli'
+chain = Chain.GOERLI
 client = in3.Client(chain, cache_enabled=False)
 address = client.ens_address(domain)
 # owner = client.ens_owner(domain)
 # _print()
 
 # Instantiate In3 Client for Mainnet
-chain = 'mainnet'
+chain = Chain.MAINNET
 client = in3.Client(chain, cache_enabled=False)
 address = client.ens_address(domain)
 owner = client.ens_owner(domain)
 _print()
 
 # Instantiate In3 Client for Kovan
-chain = 'kovan'
+chain = Chain.KOVAN
 client = in3.Client(chain, cache_enabled=True)
 try:
     address = client.ens_address(domain)

--- a/python/examples/resolve_eth_names.py
+++ b/python/examples/resolve_eth_names.py
@@ -3,7 +3,7 @@ Resolves ENS domains to Ethereum addresses
 ENS is a smart-contract system that registers and resolves `.eth` domains.
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 def _print():

--- a/python/examples/send_transaction.py
+++ b/python/examples/send_transaction.py
@@ -5,7 +5,7 @@ Works with included `data` field for smart-contract calls.
 """
 import json
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 import time
 
 

--- a/python/examples/send_transaction.py
+++ b/python/examples/send_transaction.py
@@ -5,6 +5,7 @@ Works with included `data` field for smart-contract calls.
 """
 import json
 import in3
+from in3.model import Chain
 import time
 
 
@@ -17,8 +18,8 @@ receiver = input("Receiver address: ")
 #              1000000000 == 1 Gwei Check https://etherscan.io/gasTracker.
 value_in_wei = 1463926659
 # None for Eth mainnet
-chain = 'goerli'
-client = in3.Client(chain if chain else 'mainnet')
+chain = Chain.GOERLI
+client = in3.Client(chain if chain else Chain.MAINNET)
 # A transaction is only final if a certain number of blocks are mined on top of it.
 # This number varies with the chain's consensus algorithm. Time can be calculated over using:
 # wait_time = blocks_for_consensus * avg_block_time_in_secs

--- a/python/examples/smart_contract.py
+++ b/python/examples/smart_contract.py
@@ -3,7 +3,7 @@ Manually calling ENS smart-contract
 ![UML Sequence Diagram of how Ethereum Name Service ENS resolves a name.](https://lh5.googleusercontent.com/_OPPzaxTxKggx9HuxloeWtK8ggEfIIBKRCEA6BKMwZdzAfUpIY6cz7NK5CFmiuw7TwknbhFNVRCJsswHLqkxUEJ5KdRzpeNbyg8_H9d2RZdG28kgipT64JyPZUP--bAizozaDcxCq34)
 """
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 
 
 client = in3.Client(Chain.GOERLI)

--- a/python/examples/smart_contract.py
+++ b/python/examples/smart_contract.py
@@ -3,9 +3,10 @@ Manually calling ENS smart-contract
 ![UML Sequence Diagram of how Ethereum Name Service ENS resolves a name.](https://lh5.googleusercontent.com/_OPPzaxTxKggx9HuxloeWtK8ggEfIIBKRCEA6BKMwZdzAfUpIY6cz7NK5CFmiuw7TwknbhFNVRCJsswHLqkxUEJ5KdRzpeNbyg8_H9d2RZdG28kgipT64JyPZUP--bAizozaDcxCq34)
 """
 import in3
+from in3.model import Chain
 
 
-client = in3.Client('goerli')
+client = in3.Client(Chain.GOERLI)
 domain_name = client.ens_namehash('depraz.eth')
 ens_registry_addr = '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e'
 ens_resolver_abi = 'resolver(bytes32):address'

--- a/python/in3/client.py
+++ b/python/in3/client.py
@@ -4,7 +4,7 @@ from in3.eth.api import EthereumApi
 from in3.eth.factory import EthObjectFactory
 from in3.libin3.enum import In3Methods
 from in3.libin3.runtime import In3Runtime
-from in3.model import In3Node, NodeList, ClientConfig, chain_configs
+from in3.model import In3Node, NodeList, ClientConfig, chain_configs, Chain
 from in3.transport import https_transport
 
 
@@ -15,16 +15,20 @@ class Client:
     Once with the latest list at hand, the client can request any other on-chain information using the same scheme.
     Args:
         chain (str): Ethereum chain to connect to. Defaults to mainnet. Options: 'mainnet', 'kovan', 'goerli', 'ewc'.
+            Constants available in in3.model.Chain.
         in3_config (ClientConfig or str): (optional) Configuration for the client. If not provided, default is loaded.
         cache_enabled (bool): False will disable local storage caching.
         transport (function): Transport function for custom request routing. Defaults to https.
     """
 
-    def __init__(self, chain: str = 'mainnet', in3_config: ClientConfig = None, cache_enabled: bool = True,
+    def __init__(self, chain: str = Chain.MAINNET, in3_config: ClientConfig = None, cache_enabled: bool = True,
                  transport=https_transport):
 
-        if not isinstance(chain, str) or chain.lower() not in ['mainnet', 'kovan', 'goerli', 'ewc']:
-            raise AssertionError('Client: Chain name not supported. Try mainnet, kovan, goerli, ewc.')
+        if not isinstance(chain, str) or chain.lower() not in [Chain.MAINNET, Chain.KOVAN, Chain.GOERLI, Chain.EWC]:
+            err_text = 'Client: Chain name not supported. Try {}, {}, {}, or {}.'.format(
+                Chain.MAINNET, Chain.KOVAN, Chain.GOERLI, Chain.EWC
+            )
+            raise AssertionError(err_text)
         # TODO: Clear Chain-configs
         if in3_config and not isinstance(in3_config, ClientConfig):
             raise AssertionError('Client: Use in3.ClientConfig to create a new client configuration instance.')

--- a/python/in3/eth/constants.py
+++ b/python/in3/eth/constants.py
@@ -1,0 +1,7 @@
+class Chain:
+    MAINNET = "mainnet"
+    KOVAN = "kovan"
+    EVAN = "evan"
+    GOERLI = "goerli"
+    IPFS = "ipfs"
+    EWC = "ewc"

--- a/python/in3/model.py
+++ b/python/in3/model.py
@@ -4,6 +4,7 @@ MVC Pattern Model domain classes for the Incubed client module
 import warnings
 
 from in3.eth.model import DataTransferObject, Account
+from in3.eth.constants import Chain
 
 
 class In3Node(DataTransferObject):
@@ -51,15 +52,6 @@ class NodeList(DataTransferObject):
         self.registryId = registryId
         self.lastBlockNumber = lastBlockNumber
         self.totalServers = totalServers
-
-
-class Chain:
-    MAINNET = "mainnet"
-    KOVAN = "kovan"
-    EVAN = "evan"
-    GOERLI = "goerli"
-    IPFS = "ipfs"
-    EWC = "ewc"
 
 
 class ClientConfig(DataTransferObject):

--- a/python/in3/model.py
+++ b/python/in3/model.py
@@ -53,6 +53,15 @@ class NodeList(DataTransferObject):
         self.totalServers = totalServers
 
 
+class Chain:
+    MAINNET = "mainnet"
+    KOVAN = "kovan"
+    EVAN = "evan"
+    GOERLI = "goerli"
+    IPFS = "ipfs"
+    EWC = "ewc"
+
+
 class ClientConfig(DataTransferObject):
     """
     Determines the behavior of the in3 client, which chain to connect to and how to manage information security policies.
@@ -139,43 +148,43 @@ class ChainConfig:
 
 
 chain_configs = {
-    "mainnet": ChainConfig(
+    Chain.MAINNET: ChainConfig(
         chain_id=int(0x1),
-        chain_id_alias="mainnet",
+        chain_id_alias=Chain.MAINNET,
         client_config=ClientConfig(
             chain_finality_threshold=10,
             latest_block_stall=10,
             node_signatures=2)
     ),
-    "kovan": ChainConfig(
+    Chain.KOVAN: ChainConfig(
         chain_id=int(0x2a),
-        chain_id_alias="kovan",
+        chain_id_alias=Chain.KOVAN,
         client_config=ClientConfig(
             chain_finality_threshold=1,
             latest_block_stall=6,
             node_signatures=1,
             node_signature_consensus=3)
     ),
-    "evan": ChainConfig(
+    Chain.EVAN: ChainConfig(
         chain_id=int(0x4b1),
-        chain_id_alias="evan",
+        chain_id_alias=Chain.EVAN,
         client_config=ClientConfig(
             chain_finality_threshold=1,
             latest_block_stall=6,
             node_signatures=0,
             node_signature_consensus=5)
     ),
-    "goerli": ChainConfig(
+    Chain.GOERLI: ChainConfig(
         chain_id=int(0x5),
-        chain_id_alias="goerli",
+        chain_id_alias=Chain.GOERLI,
         client_config=ClientConfig(
             chain_finality_threshold=1,
             latest_block_stall=6,
             node_signatures=2)
     ),
-    "ipfs": ChainConfig(
+    Chain.IPFS: ChainConfig(
         chain_id=int(0x7d0),
-        chain_id_alias="ipfs",
+        chain_id_alias=Chain.IPFS,
         client_config=ClientConfig(
             chain_finality_threshold=1,
             latest_block_stall=5,
@@ -183,9 +192,9 @@ chain_configs = {
             node_signature_consensus=1
         )
     ),
-    "ewc": ChainConfig(
+    Chain.EWC: ChainConfig(
         chain_id=int(0xf6),
-        chain_id_alias="ewc",
+        chain_id_alias=Chain.EWC,
         client_config=ClientConfig(
             chain_finality_threshold=1,
             latest_block_stall=6,

--- a/python/tests/integrated/negative/client_test.py
+++ b/python/tests/integrated/negative/client_test.py
@@ -4,6 +4,7 @@ Integrated negative tests for `in3` module. Doesnt test submodules.
 import unittest
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -158,15 +159,15 @@ class ClientParsingTest(unittest.TestCase):
 class KovanClientTest(ClientNegativeTest):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
 
 class GoerliClientTest(ClientNegativeTest):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.GOERLI', in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
 
 if __name__ == '__main__':

--- a/python/tests/integrated/negative/client_test.py
+++ b/python/tests/integrated/negative/client_test.py
@@ -4,7 +4,7 @@ Integrated negative tests for `in3` module. Doesnt test submodules.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/negative/eth_api_test.py
+++ b/python/tests/integrated/negative/eth_api_test.py
@@ -4,6 +4,7 @@ Integrated negative tests for `in3.eth` module.
 import unittest
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -105,15 +106,15 @@ class ParsingTest(unittest.TestCase):
 class NegativeGoerliTest(EthereumNegativeTest):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.goerli, in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
 
 class NegativeKovanTest(EthereumNegativeTest):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
 
 if __name__ == '__main__':

--- a/python/tests/integrated/negative/eth_api_test.py
+++ b/python/tests/integrated/negative/eth_api_test.py
@@ -4,7 +4,7 @@ Integrated negative tests for `in3.eth` module.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/positive/client_test.py
+++ b/python/tests/integrated/positive/client_test.py
@@ -2,9 +2,9 @@
 Integrated tests for `in3` module. Doesnt test submodules.
 """
 import unittest
-from pathlib import Path
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -18,7 +18,7 @@ class MainNetClientTest(unittest.TestCase):
     def test_configure(self):
         client = in3.Client()
         self.assertIsInstance(client, in3.Client)
-        client = in3.Client('mainnet')
+        client = in3.Client(Chain.MAINNET)
         self.assertIsInstance(client, in3.Client)
         client = in3.Client('mainNet')
         self.assertIsInstance(client, in3.Client)
@@ -72,15 +72,15 @@ class MainNetClientCachedTest(MainNetClientTest):
 class KovanClientTest(MainNetClientTest):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_configure(self):
-        client = in3.Client('kovan')
+        client = in3.Client(Chain.KOVAN)
         self.assertIsInstance(client, in3.Client)
         client = in3.Client('koVan')
         self.assertIsInstance(client, in3.Client)
-        client = in3.Client('kovan', in3.model.ClientConfig())
+        client = in3.Client(Chain.KOVAN, in3.model.ClientConfig())
         self.assertIsInstance(client, in3.Client)
 
     def test_ens_resolve(self):
@@ -91,15 +91,15 @@ class KovanClientTest(MainNetClientTest):
 class GoerliClientTest(MainNetClientTest):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.GOERLI, in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_configure(self):
-        client = in3.Client('goerli')
+        client = in3.Client(Chain.GOERLI)
         self.assertIsInstance(client, in3.Client)
         client = in3.Client('goErli')
         self.assertIsInstance(client, in3.Client)
-        client = in3.Client('goerli', in3.model.ClientConfig())
+        client = in3.Client(Chain.GOERLI, in3.model.ClientConfig())
         self.assertIsInstance(client, in3.Client)
 
     def test_ens_resolve(self):

--- a/python/tests/integrated/positive/client_test.py
+++ b/python/tests/integrated/positive/client_test.py
@@ -4,7 +4,7 @@ Integrated tests for `in3` module. Doesnt test submodules.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/positive/eth_account_test.py
+++ b/python/tests/integrated/positive/eth_account_test.py
@@ -4,7 +4,7 @@ Integrated tests for `in3.eth.account` module.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/positive/eth_account_test.py
+++ b/python/tests/integrated/positive/eth_account_test.py
@@ -4,6 +4,7 @@ Integrated tests for `in3.eth.account` module.
 import unittest
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -11,8 +12,8 @@ from tests.integrated.mock.transport import mock_transport
 class EthAccountGoerliTestCase(unittest.TestCase):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.GOERLI, in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_checksum_address(self):
         missing_0x_address = '1fe2e9bf29AA1938859aF64C413361227d04059A'
@@ -81,8 +82,8 @@ class EthAccountGoerliTestCase(unittest.TestCase):
 class EthAccountKovanTestCase(EthAccountGoerliTestCase):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_get_transaction_count(self):
         rpc = self.client.eth.account.transaction_count('0x0b56Ae81586D2728Ceaf7C00A6020C5D63f02308')

--- a/python/tests/integrated/positive/eth_api_test.py
+++ b/python/tests/integrated/positive/eth_api_test.py
@@ -4,6 +4,7 @@ Integrated tests for `in3.eth` module.
 import unittest
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -67,8 +68,8 @@ class EthereumTest(unittest.TestCase):
 class EthereumGoerliTest(EthereumTest):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.GOERLI, in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_get_block_by_number(self):
         block = self.client.eth.block_by_number(2581719)
@@ -91,8 +92,8 @@ class EthereumGoerliTest(EthereumTest):
 class EthereumKovanTest(EthereumTest):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_get_block_by_number(self):
         block = self.client.eth.block_by_number(18135233)

--- a/python/tests/integrated/positive/eth_api_test.py
+++ b/python/tests/integrated/positive/eth_api_test.py
@@ -4,7 +4,7 @@ Integrated tests for `in3.eth` module.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/positive/eth_contract_test.py
+++ b/python/tests/integrated/positive/eth_contract_test.py
@@ -4,7 +4,7 @@ Integrated tests for `in3.eth.contract` module.
 import unittest
 
 import in3
-from in3.model import Chain
+from in3.eth.constants import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 

--- a/python/tests/integrated/positive/eth_contract_test.py
+++ b/python/tests/integrated/positive/eth_contract_test.py
@@ -4,6 +4,7 @@ Integrated tests for `in3.eth.contract` module.
 import unittest
 
 import in3
+from in3.model import Chain
 from tests.integrated.mock.config import mock_config
 from tests.integrated.mock.transport import mock_transport
 
@@ -97,8 +98,8 @@ class MainNetContractTest(unittest.TestCase):
 class GoerliContractTest(MainNetContractTest):
 
     def setUp(self):
-        # self.client = in3.Client('goerli', in3_config=mock_config)
-        self.client = in3.Client('goerli', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.GOERLI, in3_config=mock_config)
+        self.client = in3.Client(Chain.GOERLI, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_eth_call(self):
         tx = {
@@ -121,8 +122,8 @@ class GoerliContractTest(MainNetContractTest):
 class KovanContractTest(MainNetContractTest):
 
     def setUp(self):
-        # self.client = in3.Client('kovan', in3_config=mock_config)
-        self.client = in3.Client('kovan', in3_config=mock_config, cache_enabled=False, transport=mock_transport)
+        # self.client = in3.Client(Chain.KOVAN, in3_config=mock_config)
+        self.client = in3.Client(Chain.KOVAN, in3_config=mock_config, cache_enabled=False, transport=mock_transport)
 
     def test_eth_call(self):
         # TODO: Future


### PR DESCRIPTION
### Summary

Creates chain constants such as "mainnet" or "goerli" now accessible as Chain.MAINNET or Chain.GOERLI. Replaces the use of these constants through the code to use the available constants.

### Other Information

This afford Pycharm type hints and allows the same constants to not have to be redefined down stream in apps/libs that use this library.  It also makes the code look more polished.

Finally, if your pull request affects documentation or any non-code
changes, please explain.

Thanks for contributing to incubed! -->

I updated the documentation to show using these constants in cases where the chain name was being specified.
