### PR TITLE
Fix memory leak cache set item

### DIFF
--- a/c/src/core/client/plugin.h
+++ b/c/src/core/client/plugin.h
@@ -85,7 +85,7 @@ in3_ret_t in3_plugin_execute_first_or_none(in3_ctx_t* ctx, in3_plugin_act_t acti
 // ----------- RPC HANDLE -----------
 
 /**
- * verification context holding the pointers to all relevant toknes.
+ * verification context holding the pointers to all relevant tokens.
  */
 typedef struct {
   in3_ctx_t*       ctx;      /**< Request context. */

--- a/c/src/core/client/plugin.h
+++ b/c/src/core/client/plugin.h
@@ -63,7 +63,7 @@ in3_ret_t in3_plugin_register(
 /** registers a plugin and uses the function name as plugin name */
 #define plugin_register(c, acts, action_fn, data, replace_ex) in3_plugin_register(#action_fn, c, acts, action_fn, data, replace_ex)
 /**
- * adds a plugin rregister function to the default. All defaults functions will automaticly called and registered for every new in3_t instance.
+ * adds a plugin rregister function to the default. All defaults functions will automatically called and registered for every new in3_t instance.
  */
 void in3_register_default(plgn_register reg_fn);
 

--- a/python/in3/libin3/storage.py
+++ b/python/in3/libin3/storage.py
@@ -26,7 +26,7 @@ def set_item(_cptr, key, value):
         key: File name to be stored.
         value: File contents.
     """
-    key = c.string_at(key).decode('utf8')
+    key = c.string_at(key, c.sizeof(key)).decode('utf8')
     path.mkdir(parents=True, exist_ok=True)
     try:
         value = c.string_at(value.contents.data, value.contents.len)


### PR DESCRIPTION
### Summary

Fixes a bug preventing the cache from saving an ens address lookup correctly (or at all).
Also fixes a few spelling errors I found when debugging this problem.

### Other Information

Addresses an issue I raised earlier today: https://github.com/blockchainsllc/in3-c/issues/22
See the issue for more details!